### PR TITLE
style for eula & privacy

### DIFF
--- a/apps/docs/eula.md
+++ b/apps/docs/eula.md
@@ -15,22 +15,17 @@ By clicking the "Accept" button for this Agreement and/or using the Software, yo
 
     THE SOFTWARE IS MADE AVAILABLE “AS IS”, “WITH ALL FAULTS” AND “AS AVAILABLE.”  WE DISCLAIM ALL EXPRESS OR IMPLIED WARRANTIES, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, SATISFACTORY QUALITY AND NON-INFRINGEMENT.  WE MAKE NO WARRANTY THAT THE SOFTWARE IS OR WILL BE UNINTERRUPTED, SECURE OR ERROR-FREE.  IN NO EVENT SHALL WE BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, PUNITIVE, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, SAVINGS OR PROFITS; OR BUSINESS INTERRUPTION), IN EACH CASE HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF OR INABILITY TO USE THE SOFTWARE OR OTHERWISE IN CONNECTION WITH THIS AGREEMENT, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  
 
-
     OUR ENTIRE LIABILITY UNDER THIS AGREEMENT SHALL NOT EXCEED THE TOTAL FEES PAID, IF ANY, BY YOU UNDER THIS AGREEMENT.  
 
-
     YOU AGREE THAT ANY CLAIM OR CAUSE OF ACTION ARISING OUT OF OR RELATED TO THE SOFTWARE OR THIS AGREEMENT MUST BE FILED WITHIN ONE (1) YEAR AFTER SUCH CLAIM OR CAUSE OF ACTION AROSE OR BE FOREVER BARRED. SOME JURISDICTIONS DO NOT ALLOW IMPLIED WARRANTIES TO BE EXCLUDED OR MODIFIED OR LIABILITY TO BE LIMITED, SO NOT ALL OF THE ABOVE LIMITATIONS MAY APPLY TO YOU, AND THESE DISCLAIMERS AND WARRANTIES ARE MADE ONLY TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW. 
-
 
     The disclaimers of warranty and limitations of liability set forth above are fundamental elements of the basis of the bargain between you and us, and you acknowledge and agree that we would not provide the Software to you without these limitations.
 
 5. General.  The laws of the State of Wyoming, U.S.A., excluding its conflicts of law rules, govern this Agreement and your use of the Software.  The UN Convention on Contracts for the International Sale of Goods is disclaimed.  You agree that exclusive jurisdiction for any claim or dispute arising from this Agreement shall be in the federal and state courts located in Cheyenne, Wyoming, U.S.A. 
 
     You may not assign or transfer this Agreement or any rights hereunder, and any attempt to the contrary is void.   Subject to the preceding sentence, this Agreement benefits and binds the respective successors and assigns of the parties.  
-
-
+    
     If any provision of this Agreement is held to be invalid or unenforceable, such provision shall be struck and the remaining provisions shall be enforced. Our failure to act with respect to a breach of this Agreement by you or others does not waive our right to act with respect to subsequent or similar breaches. 
-
 
     This Agreement constitutes the entire agreement between the parties relating to the subject matter of this Agreement and supersedes all prior or contemporaneous written or oral agreements, representations, warranties, understandings or communications between the parties with respect to such subject matter.  
 
@@ -38,24 +33,17 @@ By clicking the "Accept" button for this Agreement and/or using the Software, yo
 
     The license granted to you in this Agreement is limited to a non-transferable license to use the Software on any Apple-branded products that you own or control and as permitted by the Usage Rules set forth in the App Store Terms of Service, except that the Software  may be accessed, acquired, and used by other accounts associated with you via Family Sharing or volume purchasing.
 
-
     We are solely responsible for providing any maintenance and support services with respect to the Software, as specified in this Agreement, or as required under applicable law. Apple has no obligation whatsoever to furnish any maintenance and support services with respect to the Software.
-
 
     We are solely responsible for any product warranties, whether expressed or implied by law, to the extent not effectively disclaimed. In the event of any failure of the Software  to conform to any applicable warranty, you may notify Apple, and Apple will refund the purchase price for the Software to you; and that, to the maximum extent permitted by applicable law, Apple will have no other warranty obligation whatsoever with respect to the Software. Any other claims, losses, liabilities, damages, costs or expenses attributable to any failure to conform to any warranty will be our sole responsibility, subject to this Agreement and applicable law.
 
-
     We, not Apple, are responsible for addressing any claims relating to the Software or your  possession and/or use of the Software, including, but not limited to: (i) product liability claims; (ii) any claim that the Software fails to conform to any applicable legal or regulatory requirement; and (iii) claims arising under consumer protection or similar legislation. The Agreement expressly limits our liability to the extent permitted by applicable law.
-
 
     In the event of any third party claim that the Software  or your possession and use of that Software infringes that third party’s intellectual property rights, we, not Apple, will be solely responsible for any investigation, defense, settlement and discharge of any such intellectual property infringement claim.
 
-
     You represent and warrant that (i) you are not located in a country that is subject to a U.S. Government embargo, or that has been designated by the U.S. Government as a “terrorist supporting” country; and (ii) you are not listed on any U.S. Government list of prohibited or restricted parties.
 
-
     You must comply with all applicable third party terms of agreement when using the Software.
-
 
     Apple, and Apple’s subsidiaries, are third party beneficiaries of this Agreement, and that, upon your acceptance of the terms and conditions of the Agreement, Apple will have the right (and will be deemed to have accepted the right) to enforce the Agreement  against you as a third party beneficiary thereof.
 
@@ -66,6 +54,4 @@ Bitmark Inc.
 1F No.489-1, Chongyang Rd.  
 Nangang Taipei Taiwan 115  
 +886 2-26515982  
-[support@bitmark.com](mailto:support@bitmark.com)  
-
-
+[support@bitmark.com](mailto:support@bitmark.com)

--- a/apps/docs/privacy.md
+++ b/apps/docs/privacy.md
@@ -1,12 +1,12 @@
 # Autonomy Privacy Policy
 
 
-## Last Updated: 4-JUL, 2022
+### Last Updated: 4-JUL, 2022
 
 Bitmark Inc. (“Bitmark”, “we”, “us”, “our”) provides this Privacy Policy to inform users of our policies and procedures regarding the collection, use and disclosure of personally identifiable information received from users of Bitmark’s Autonomy mobile application (the “Application”) and the related hosted service (collectively the "Services"), and the Autonomy website, (the “Website”).  Any terms not defined in this Privacy Policy are defined in our [Terms of Service](terms.md).
 
 
-# Definitions
+## Definitions
 
 
 
@@ -14,7 +14,7 @@ Bitmark Inc. (“Bitmark”, “we”, “us”, “our”) provides this Privac
 * “Personally identifiable information” is information traditionally thought of as directly identifying a natural living person, such as full names, addresses, telephone numbers, government identification numbers, payment information, email addresses, social network identifiers, App Provider account identifiers and similar persistent and public or quasi-public identifiers.  
 
 
-# Services Information Collection and Use
+## Services Information Collection and Use
 
 You will need to create a user account (the “Account”) in order to use the Services.  We will collect personally identifiable information from you in order to establish the Account, which may include information we request from you in order to satisfy our legal obligations to know our customers, and to collect payment from you.
 
@@ -29,7 +29,7 @@ Finally, the Services collect personal information about your use of our Service
 We use personal information collected through the Services only to provide the Services to you (including communicating with you about administrative and technical matters), to fulfill our legal or regulatory obligations, and to secure, maintain, and improve the Services.
 
 
-# Website Information Collection and Use
+## Website Information Collection and Use
 
 It is not necessary to provide us with personally identifiable information to access or use the Website, and we do not collect personally identifiable information in connection with the ordinary operation of the Website.  We do collect personal information from the Website, as described below, but we do not associate that personal information with the personal information in the Services or with correspondence you may send us as described in the next paragraph.
 
@@ -38,12 +38,12 @@ If you contact us by email through the Website, we may keep a record of your con
 When you visit the Website, Company’s servers automatically record the information that your browser sends whenever you visit a website ("Log Data"). This Log Data may include information such as your IP address, browser type or the domain from which you are visiting. For most users accessing the Internet from an Internet service provider, the IP address may be different every time you log on. Company uses Log Data to monitor use of the Website and the services we offer via the Website and for the Website’s technical administration.  
 
 
-## Do Not Track
+### Do Not Track
 
 We do not use cookies to collect personally identifiable information or track users’ online activities over time and across different websites. For more information regarding Do Not Track mechanisms, see [http://allaboutdnt.com](http://allaboutdnt.com).
 
 
-## Information Shared with Others
+### Information Shared with Others
 
 
 
@@ -52,7 +52,7 @@ We do not use cookies to collect personally identifiable information or track us
 * It is our policy to protect you from having your privacy violated through abuse of the legal systems, whether by individuals, entities or government, and to contest claims that we believe to be invalid under applicable law. However, it is also our policy to cooperate with government and law enforcement officials and private parties. Accordingly, we reserve the right to disclose any information about you to government or law enforcement officials or private parties as we, in our sole discretion, believe necessary: (a) to satisfy or comply with any applicable law, regulation or legal process or to respond to lawful requests, including subpoenas, warrants or court orders; (b) to enforce our agreements with you or third parties, to protect our property, rights and safety and the rights, property and safety of third parties or the public in general; and (c) to prevent or stop activity we consider to be illegal or unethical.
 
 
-## Data Retention
+### Data Retention
 
 Generally speaking, we will retain your personal information for as long as necessary for the purposes set out in this Privacy Policy.
 
@@ -61,7 +61,7 @@ We retain personal information for as long as it is reasonably necessary or requ
 Otherwise, we generally delete information when it is no longer reasonably necessary to provide you with the Services, to comply with applicable laws and regulations, and to run our business.
 
 
-## Security
+### Security
 
 We take reasonable technical, administrative, and organizational measures to protect your information from unauthorized access, use or disclosure of the information that we collect. The Services encrypt all information in your mobile device, in transit between your mobile device and your private virtual machine, and when stored in your private virtual machine.  
 
@@ -70,7 +70,7 @@ We do not have access to any of the information you store in the Services except
 Please be aware, however, that no method of transmitting information over the Internet or storing information is completely secure. Accordingly, we cannot guarantee the absolute security of any information.
 
 
-## Your Rights in Your Data
+### Your Rights in Your Data
 
 Bitmark doesn't collect, process, or disclose your personal data in connection with the Services except as we describe in this Privacy Policy.  Under applicable laws of various countries or US States, you may have certain rights concerning your personal data, such as under EU or California law, the right to access to, rectification or erasure of, and/or restriction of processing or objection to processing of your personal data.  If you wish to exercise your rights with respect to personal data collected or processed by Bitmark in connection with the Services, contact us via email at [support@bitmark.com](mailto:support@bitmark.com),  and we will respond to you with specific instructions to follow.
 
@@ -84,21 +84,21 @@ Please note, that as described above:
 If you are a resident in the European Union, you also have the right at no cost to lodge a complaint with EU data protection authorities. This right may also exist in other countries.  
 
 
-## International Transfer
+### International Transfer
 
 Your information (including personally identifiable information) may be transferred to, and maintained on, computers located outside of your state, province, country or other governmental jurisdiction where the privacy laws may not be as protective as those in your jurisdiction. By using the Services, you consent to this transfer.
 
 
-## Links to Other Sites
+### Links to Other Sites
 
 The Website may contain links to other websites ("Linked Sites") operated by Bitmark or third parties. Linked Sites may place their own cookies or other files on your computer, collect data or solicit personal information from you. This Privacy Policy addresses only the use and disclosure of information that Bitmark collects through the Services. Other sites follow different rules regarding the use or disclosure of the personal information you submit to them. Bitmark does not exercise control over third party Linked Sites. Your use of any Linked Site operated by Bitmark is subject to the terms and conditions provided by Bitmark for such Linked Site.  Bitmark encourages you to read the privacy policies or statements of the other websites you visit.
 
 
-## Our Policy Towards Children
+### Our Policy Towards Children
 
 The Services are not directed to children under 18. If a parent or guardian becomes aware that his or her child has provided us with personally identifiable information without their consent, he or she should contact us at [support@bitmark.com](mailto:support@bitmark.com). If we become aware that a child under 13 has provided personally identifiable information to us, we will remove such information from our files and will not make further use of it.
 
 
-## Changes to this Privacy Policy
+### Changes to this Privacy Policy
 
 We reserve the right to change this policy at any time without prior notice. Any changes to this policy will be posted here, and we will attempt to notify you through the Application or at the email address you have provided to us.  You are advised to consult this Privacy Policy regularly for any changes. If you have any questions or comments about this Privacy Policy, please contact us at [support@bitmark.com](mailto:support@bitmark.com).


### PR DESCRIPTION
Some rules to assure content shows in app correctly:
- heading1 - # is used as title: its bottom padding is 40px. So should use other heading from heading2.
- ONLY one new line for list item. 
for unknown issue in markdown lib, if it's multiple line will make text cutted.
<img src=https://user-images.githubusercontent.com/50816149/177706160-c5e09819-b846-4ca3-8a46-236f56c60880.png width=200 />


Result: https://bitmark.slack.com/archives/C01EPPD07HU/p1657175385453859?thread_ts=1657078100.908339&cid=C01EPPD07HU